### PR TITLE
feat: Add GitHub Action for Clippy linting on multiple OS

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,34 @@
+name: Clippy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout self
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Setup MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+          toolset: 14.29
+          sdk: 10.0.19041.0
+
+      - name: Cargo clippy
+        run: |
+          cargo clippy --all


### PR DESCRIPTION
#### Fixs: #5 

This workflow runs Clippy on push to main branch and on manual dispatch, ensuring code quality across Ubuntu, Windows, and macOS.