### PR TITLE
Remove SDK version from clippy.yml

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           arch: x64
           toolset: 14.29
-          sdk: 10.0.19041.0
 
       - name: Cargo clippy
         run: |


### PR DESCRIPTION
Removed SDK version from clippy workflow. Fix Build BUG！